### PR TITLE
Fix incorrect text-align css

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -40,7 +40,7 @@ export default {
     font-size: 20px;
     border-radius: 4px;
     border: 1px solid rgba(0, 0, 0, 0.3);
-    textalign: "center";
+    text-align: center;
     &.error {
       border: 1px solid red !important;
     }


### PR DESCRIPTION
The `text-align` CSS property is incorrectly used. This PR fixes that.