### PR TITLE
Turn off number input spinners

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -45,4 +45,9 @@ export default {
       border: 1px solid red !important;
     }
   }
+  .otp-input::-webkit-inner-spin-button,
+  .otp-input::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
 </style>


### PR DESCRIPTION
Event though the CSS property `text-align: center` has been applied to the `otp-input` class, the digits are not actually centred because of the number input spinners being present. This PR aims to fix that.

**Before**
![before-spinner-removed](https://user-images.githubusercontent.com/7896438/73651258-1477c680-46aa-11ea-933f-76e0a2a4e332.gif)

**After**
![after-spinner-removed](https://user-images.githubusercontent.com/7896438/73651266-18a3e400-46aa-11ea-94f0-44a049ac0a84.gif)
