### PR TITLE
Added function to clear input and reset focus of input

### DIFF
--- a/src/components/OtpInput.vue
+++ b/src/components/OtpInput.vue
@@ -115,6 +115,10 @@ export default {
       this.changeCodeAtFocus(value);
       this.focusNextInput();
     },
+    clearInput() {
+      this.otp = [];
+      this.activeInput = 0;
+    },
     // Handle cases of backspace, delete, left arrow, right arrow
     handleOnKeyDown(event) {
       switch (event.keyCode) {


### PR DESCRIPTION
Ive added the functionality to clear the input of the otp based on an event such as clicking a button. You can do this programattically by calling the following 

```js
this.$refs.otp_iput.clearInput();
```

usage would be : 
```vue
<template>
  <div>
    <v-otp-input
      input-classes="otp-input"
      separator="-"
      :num-inputs="4"
      :should-auto-focus="true"
      :is-input-num="true"
      @on-change="handleOnChange"
      @on-complete="handleOnComplete"
      ref="otp_iput"
    />
    <button @click="handleClearInput()">Clear Input</button>
  </div>
</template>

<script>
import OtpInput from './components';

export default {
  name: 'App',
  components: {
    'v-otp-input': OtpInput,
  },
  methods: {
    handleOnComplete(value) {
      console.log('OTP completed: ', value);
    },
    handleOnChange(value) {
      console.log('OTP changed: ', value);
    },
    handleClearInput() {
      this.$refs.otp_iput.clearInput();
    },
  },
};
</script>

<style lang="less">
  .otp-input {
    width: 40px;
    height: 40px;
    padding: 5px;
    margin: 0 10px;
    font-size: 20px;
    border-radius: 4px;
    border: 1px solid rgba(0, 0, 0, 0.3);
    textalign: "center";
    &.error {
      border: 1px solid red !important;
    }
  }
</style>

```