### PR TITLE
Add feature to disallow certain characters like "." or "e"

### DIFF
--- a/src/components/SingleOtpInput.vue
+++ b/src/components/SingleOtpInput.vue
@@ -79,13 +79,16 @@ export default {
       return this.$emit('on-change', this.model);
     },
     handleOnKeyDown(event) {
-      // Disallow non-numerical characters such as "." and "e"
+      // Only allow characters 0-9, DEL, Backspace and Pasting
       const keyevent = (event) || window.event;
       const charCode = (keyevent.which) ? keyevent.which : keyevent.keyCode;
-      if ((charCode > 31 && (charCode < 48 || charCode > 57)) || charCode === 46) {
-        keyevent.preventDefault();
-      } else {
+      if ((charCode >= 48 && charCode <= 57)
+          || (charCode === 8)
+          || (charCode === 86)
+          || (charCode === 46)) {
         this.$emit('on-keydown', event);
+      } else {
+        keyevent.preventDefault();
       }
     },
     handleOnPaste(event) {

--- a/src/components/SingleOtpInput.vue
+++ b/src/components/SingleOtpInput.vue
@@ -83,7 +83,7 @@ export default {
       const keyevent = (event) || window.event;
       const charCode = (keyevent.which) ? keyevent.which : keyevent.keyCode;
       if ((charCode > 31 && (charCode < 48 || charCode > 57)) || charCode === 46) {
-        event.preventDefault();
+        keyevent.preventDefault();
       } else {
         this.$emit('on-keydown', event);
       }

--- a/src/components/SingleOtpInput.vue
+++ b/src/components/SingleOtpInput.vue
@@ -79,7 +79,14 @@ export default {
       return this.$emit('on-change', this.model);
     },
     handleOnKeyDown(event) {
-      return this.$emit('on-keydown', event);
+      // Disallow non-numerical characters such as "." and "e"
+      const keyevent = (event) || window.event;
+      const charCode = (keyevent.which) ? keyevent.which : keyevent.keyCode;
+      if ((charCode > 31 && (charCode < 48 || charCode > 57)) || charCode === 46) {
+        event.preventDefault();
+      } else {
+        this.$emit('on-keydown', event);
+      }
     },
     handleOnPaste(event) {
       return this.$emit('on-paste', event);


### PR DESCRIPTION
Right now you can enter characters such as . or e in the input, as far as i'm aware this should only allow numerical characters. 