### PR TITLE
Adds alphanumeric support and v-model support

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,2 @@
+singleQuote: true
+trailingComma: true

--- a/src/components/OtpInput.vue
+++ b/src/components/OtpInput.vue
@@ -1,13 +1,13 @@
 <template>
-  <div style="display: flex">
+  <div style="display: flex;">
     <SingleOtpInput
       v-for="(item, i) in numInputs"
       :key="i"
+      class="v-otp-input"
       :focus="activeInput === i"
       :value="otp[i]"
       :separator="separator"
       :input-classes="inputClasses"
-      :is-last-child="i === numInputs - 1"
       :should-auto-focus="shouldAutoFocus"
       :is-input-num="isInputNum"
       @on-change="handleOnChange"
@@ -39,7 +39,7 @@ export default {
     },
     separator: {
       type: String,
-      default: '**',
+      default: '',
     },
     inputClasses: {
       type: String,
@@ -50,6 +50,9 @@ export default {
     shouldAutoFocus: {
       type: Boolean,
       default: false,
+    },
+    value: {
+      type: [String, Number],
     },
   },
   data() {
@@ -116,7 +119,7 @@ export default {
       this.focusNextInput();
     },
     clearInput() {
-      if(this.otp.length > 0) {
+      if (this.otp.length > 0) {
         this.$emit('on-change', '');
       }
       this.otp = [];
@@ -147,5 +150,15 @@ export default {
       }
     },
   },
+  watch: {
+    otp() {
+      this.$emit('input', this.otp.join(''));
+    },
+  },
 };
 </script>
+<style scoped>
+.v-otp-input:last-child >>> .v-otp-separator {
+  display: none;
+}
+</style>

--- a/src/components/OtpInput.vue
+++ b/src/components/OtpInput.vue
@@ -39,7 +39,6 @@ export default {
     },
     separator: {
       type: String,
-      default: '',
     },
     inputClasses: {
       type: String,

--- a/src/components/OtpInput.vue
+++ b/src/components/OtpInput.vue
@@ -10,11 +10,11 @@
       :input-classes="inputClasses"
       :should-auto-focus="shouldAutoFocus"
       :is-input-num="isInputNum"
-      @on-change="handleOnChange"
-      @on-keydown="handleOnKeyDown"
-      @on-paste="handleOnPaste"
-      @on-focus="handleOnFocus(i)"
-      @on-blur="handleOnBlur"
+      @change="handleOnChange"
+      @keydown="handleOnKeyDown"
+      @paste="handleOnPaste"
+      @focus="handleOnFocus(i)"
+      @blur="handleOnBlur"
     />
   </div>
 </template>

--- a/src/components/SingleOtpInput.vue
+++ b/src/components/SingleOtpInput.vue
@@ -2,10 +2,10 @@
   <div style="display: flex; align-items: center;">
     <input
       :class="inputClasses"
-      :type="isInputNum ? 'number' : 'tel'"
-      min="0"
-      max="9"
       ref="input"
+      :type="isInputNum ? 'number' : 'text'"
+      :min="isInputNum ? '0' : ''"
+      :max="isInputNum ? '9' : ''"
       v-model="model"
       @input="handleOnChange"
       @keydown="handleOnKeyDown"
@@ -13,9 +13,7 @@
       @focus="handleOnFocus"
       @blur="handleOnBlur"
     />
-    <span v-if="!isLastChild && separator">
-      <span v-html="separator"></span>
-    </span>
+    <span class="v-otp-separator" v-html="separator" />
   </div>
 </template>
 
@@ -40,9 +38,7 @@ export default {
     },
     isInputNum: {
       type: Boolean,
-    },
-    isLastChild: {
-      type: Boolean,
+      default: false,
     },
   },
   data() {
@@ -65,7 +61,7 @@ export default {
     focus(newFocusValue, oldFocusValue) {
       // Check if focusedInput changed
       // Prevent calling function if input already in focus
-      if (oldFocusValue !== newFocusValue && (this.$refs.input && this.focus)) {
+      if (oldFocusValue !== newFocusValue && this.$refs.input && this.focus) {
         this.$refs.input.focus();
         this.$refs.input.select();
       }
@@ -76,34 +72,35 @@ export default {
       if (this.model.length > 1) {
         this.model = this.model.slice(0, 1);
       }
-      return this.$emit('on-change', this.model);
+      return this.$emit('change', this.model);
     },
     handleOnKeyDown(event) {
       // Only allow characters 0-9, DEL, Backspace and Pasting
       const keyEvent = (event) || window.event;
       const charCode = (keyEvent.which) ? keyEvent.which : keyEvent.keyCode;
-      if (this.isCodeNumeric(charCode)
-          || (charCode === 8)
-          || (charCode === 86)
-          || (charCode === 46)) {
-        this.$emit('on-keydown', event);
+      const allowedCharCodes = [8, 86, 46];
+      if (!this.isInputNum) {
+        this.$emit('keydown', event);
+      } else if (this.isCodeNumeric(charCode) || allowedCharCodes.includes(charCode)) {
+        this.$emit('keydown', event);
       } else {
         keyEvent.preventDefault();
       }
     },
+
     isCodeNumeric(charCode) {
       // numeric keys and numpad keys
-      return (charCode >= 48 && charCode <= 57) || (charCode >= 96 && charCode <= 105)
+      return (charCode >= 48 && charCode <= 57) || (charCode >= 96 && charCode <= 105);
     },
     handleOnPaste(event) {
-      return this.$emit('on-paste', event);
+      return this.$emit('paste', event);
     },
     handleOnFocus() {
       this.$refs.input.select();
-      return this.$emit('on-focus');
+      return this.$emit('focus');
     },
     handleOnBlur() {
-      return this.$emit('on-blur');
+      return this.$emit('blur');
     },
   },
 };

--- a/src/components/SingleOtpInput.vue
+++ b/src/components/SingleOtpInput.vue
@@ -13,7 +13,7 @@
       @focus="handleOnFocus"
       @blur="handleOnBlur"
     />
-    <span class="v-otp-separator" v-html="separator" />
+    <span v-if="separator" class="v-otp-separator" v-html="separator" />
   </div>
 </template>
 
@@ -76,12 +76,15 @@ export default {
     },
     handleOnKeyDown(event) {
       // Only allow characters 0-9, DEL, Backspace and Pasting
-      const keyEvent = (event) || window.event;
-      const charCode = (keyEvent.which) ? keyEvent.which : keyEvent.keyCode;
+      const keyEvent = event || window.event;
+      const charCode = keyEvent.which ? keyEvent.which : keyEvent.keyCode;
       const allowedCharCodes = [8, 86, 46];
       if (!this.isInputNum) {
         this.$emit('keydown', event);
-      } else if (this.isCodeNumeric(charCode) || allowedCharCodes.includes(charCode)) {
+      } else if (
+        this.isCodeNumeric(charCode) ||
+        allowedCharCodes.includes(charCode)
+      ) {
         this.$emit('keydown', event);
       } else {
         keyEvent.preventDefault();
@@ -90,7 +93,10 @@ export default {
 
     isCodeNumeric(charCode) {
       // numeric keys and numpad keys
-      return (charCode >= 48 && charCode <= 57) || (charCode >= 96 && charCode <= 105);
+      return (
+        (charCode >= 48 && charCode <= 57) ||
+        (charCode >= 96 && charCode <= 105)
+      );
     },
     handleOnPaste(event) {
       return this.$emit('paste', event);


### PR DESCRIPTION
This adds support for using `v-model` instead of listening for `on-complete`.
It also adds support for using alpha numeric input, where as before it was only numeric.

Then I did some code simplifying hope that is okay.
Instead of using a boolean to add the last separator, it uses a CSS attribute ex.
Removes the default value of the separator, as per your documentation