### PR TITLE
Feature: Add support for inputmode

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,11 +122,18 @@ export default {
       <td>Input type. Optional value: "password", "number", "tel".</td>
     </tr>
   <tr>
+      <td>input-mode</td>
+      <td>string</td>
+      <td>false</td>
+      <td>"text"</td>
+      <td>Input type. Optional value: "text", "numeric", "decimal", "none".</td>
+  </tr>
+  <tr>
     <td>should-auto-focus</td>
     <td>boolean</td>
     <td>false</td>
     <td>false</td>
-    <td>Auto focuses input on inital page load.</td>
+    <td>Auto focuses input on initial page load.</td>
   </tr>
 </table>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bachdgvn/vue-otp-input",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/OtpInput.vue
+++ b/src/components/OtpInput.vue
@@ -14,6 +14,7 @@
       :separator="separator"
       :input-type="inputType"
       :input-classes="inputClasses"
+      :input-mode="inputMode"
       :is-last-child="i === numInputs - 1"
       :should-auto-focus="shouldAutoFocus"
       @on-change="handleOnChange"
@@ -54,6 +55,12 @@ export default {
       type: String,
       validator(value) {
         return ['number', 'tel', 'password'].includes(value);
+      },
+    },
+    inputMode: {
+      type: String,
+      validator(value) {
+        return ['text', 'numeric', 'tel', 'none'].includes(value);
       },
     },
     shouldAutoFocus: {

--- a/src/components/SingleOtpInput.vue
+++ b/src/components/SingleOtpInput.vue
@@ -3,6 +3,7 @@
     <input
       ref="input"
       :type="inputType"
+      :inputmode="inputMode"
       min="0"
       max="9"
       maxlength="1"
@@ -44,6 +45,12 @@ export default {
       type: String,
       default() {
         return 'tel';
+      },
+    },
+    inputMode: {
+      type: String,
+      default() {
+        return 'text';
       },
     },
     isLastChild: {


### PR DESCRIPTION
This PR adds support for the `inputmode` HTML attribute, this way users can specify the keyboard/keypad input to be displayed and help reduce the checks