### PR TITLE
Fix `handleOnKeyDown` preventing users from interacting using the keyboard

### DIFF
--- a/src/components/SingleOtpInput.vue
+++ b/src/components/SingleOtpInput.vue
@@ -84,13 +84,10 @@ export default {
       return this.$emit('on-change', this.model);
     },
     handleOnKeyDown(event) {
-      // Only allow characters 0-9, DEL, Backspace and Pasting
+      // Only allow characters 0-9, DEL, Backspace, Enter, Right and Left Arrows, and Pasting
       const keyEvent = (event) || window.event;
       const charCode = (keyEvent.which) ? keyEvent.which : keyEvent.keyCode;
-      if (this.isCodeNumeric(charCode)
-          || (charCode === 8)
-          || (charCode === 86)
-          || (charCode === 46)) {
+      if (this.isCodeNumeric(charCode) || [8, 9, 13, 37, 39, 46, 86].includes(charCode)) {
         this.$emit('on-keydown', event);
       } else {
         keyEvent.preventDefault();


### PR DESCRIPTION
This PR brings back support for using the arrow keys to navigate between inputs (probably lost with https://github.com/bachdgvn/vue-otp-input/commit/fa0ad5dfe1ab08d265b6ce714102c2fea0930279). It also addresses the fact users weren't able to tab outside the component or submit when using it inside a form.

Closes #33. Closes #36.